### PR TITLE
Pin GitHub Actions to specific commits for security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build on Linux using Apache Ant
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
       - name: Install dependencies
         run: |-


### PR DESCRIPTION
For proof that GitHub Dependabot can still keep things up to date for us with the new format see https://github.com/gentoo-ev/www.gentoo-ev.org/pull/5/files .